### PR TITLE
Fix query parsing and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cargo run -- -c config.yaml
 # Use inspector for debugging (start service first)
 npx @modelcontextprotocol/inspector node build/index.js
 # Access http://127.0.0.1:6274/
-# Select "see" and enter 0.0.0.0:8080/sse, then click connect
+# Select "SSE" and enter 0.0.0.0:8080/sse, then click connect
 # or select "Streamable HTTP" and enter 0.0.0.0:8080/mcp
 ```
 


### PR DESCRIPTION
## Summary
- fix typo in README quick start instructions
- handle query parameters without values
- clarify default empty string handling for dynamic params
- improve tenant id test and add coverage for query parsing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b65a72a2a0832c98bdc5af84d7a7c4